### PR TITLE
Add Letter Checking to Board State

### DIFF
--- a/lib/letter_lines_elixir/board_state.ex
+++ b/lib/letter_lines_elixir/board_state.ex
@@ -13,10 +13,30 @@ defmodule LetterLinesElixir.BoardState do
   def new(words) do
     {max_x, max_y} = BoardWord.get_max_size(words)
 
+    for x <- 0..(max_x - 1), y <- 0..(max_y - 1) do
+      _ = do_get_letter_at(words, x, y)
+    end
+
     %BoardState{
       width: max_x,
       height: max_y,
       words: words
     }
+  end
+
+  def get_letter_at(%BoardState{words: words}, x, y) do
+    do_get_letter_at(words, x, y)
+  end
+
+  defp do_get_letter_at(words, x, y) do
+    words
+    |> Enum.map(&BoardWord.get_letter_at(&1, x, y))
+    |> Enum.reject(&(&1 == :none))
+    |> Enum.uniq()
+    |> case do
+         [] -> :none
+         [a] -> a
+         [a | _] = list -> raise "Multiple letters found at #{x}, #{y}: #{inspect(list)}"
+       end
   end
 end

--- a/lib/letter_lines_elixir/board_word.ex
+++ b/lib/letter_lines_elixir/board_word.ex
@@ -36,8 +36,8 @@ defmodule LetterLinesElixir.BoardWord do
     Given a BoardWord, determine if a letter exists at a given coordinate. If a letter is present, it is returned.
     Otherwise return `nil`
   """
-  def get_letter_at(%BoardWord{direction: :h, y: y1}, _x, y2) when y1 != y2, do: nil
-  def get_letter_at(%BoardWord{direction: :v, x: x1}, x2, _y) when x1 != x2, do: nil
+  def get_letter_at(%BoardWord{direction: :h, y: y1}, _x, y2) when y1 != y2, do: :none
+  def get_letter_at(%BoardWord{direction: :v, x: x1}, x2, _y) when x1 != x2, do: :none
 
   def get_letter_at(%BoardWord{direction: :h, word: word, x: x1, size: size}, x2, _y) when x2 >= x1 and x2 < size + x1,
     do: String.at(word, x2 - x1)
@@ -45,5 +45,5 @@ defmodule LetterLinesElixir.BoardWord do
   def get_letter_at(%BoardWord{direction: :v, word: word, y: y1, size: size}, _x, y2) when y2 >= y1 and y2 < size + y1,
     do: String.at(word, y2 - y1)
 
-  def get_letter_at(_, _, _), do: nil
+  def get_letter_at(_, _, _), do: :none
 end


### PR DESCRIPTION
Add the ability to a BoardState to check a given coordinate for a letter that
is part of a word. Return the letter if found, a message if not, or raise
if multiple, different letters are found which indicates a faulty board state