### PR TITLE
Check more possible invalid board states

### DIFF
--- a/lib/letter_lines_elixir/board_state.ex
+++ b/lib/letter_lines_elixir/board_state.ex
@@ -17,6 +17,16 @@ defmodule LetterLinesElixir.BoardState do
       _ = do_get_letter_at(words, x, y)
     end
 
+    if !Enum.any?(0..max_x, fn x -> do_get_letter_at(words, x, 0) != :none end) do
+      raise "No letters found in first row"
+    end
+
+    if !Enum.any?(0..max_y, fn y -> do_get_letter_at(words, 0, y) != :none end) do
+      raise "No letters found in first column"
+    end
+
+    Enum.each(words, &check_inappropriate_touching(&1, words))
+
     # Add one to max to handle zero based layout
     %BoardState{
       width: max_x + 1,
@@ -44,6 +54,26 @@ defmodule LetterLinesElixir.BoardState do
       [] -> :none
       [a] -> a
       [_ | _] = list -> raise "Multiple letters found at #{x}, #{y}: #{inspect(list)}"
+    end
+  end
+
+  defp check_inappropriate_touching(%BoardWord{direction: :h, x: x, y: y, word: word, size: size}, words) do
+    if do_get_letter_at(words, x - 1, y) != :none do
+      raise "Letter found before horizontal word: #{word}"
+    end
+
+    if do_get_letter_at(words, x + size, y) != :none do
+      raise "Letter found after horizontal word: #{word}"
+    end
+  end
+
+  defp check_inappropriate_touching(%BoardWord{direction: :v, x: x, y: y, word: word, size: size}, words) do
+    if do_get_letter_at(words, x, y - 1) != :none do
+      raise "Letter found before vertical word: #{word}"
+    end
+
+    if do_get_letter_at(words, x, y + size) != :none do
+      raise "Letter found after vertical word: #{word}"
     end
   end
 end

--- a/test/letter_lines_elixir/board_state_test.exs
+++ b/test/letter_lines_elixir/board_state_test.exs
@@ -4,32 +4,32 @@ defmodule LetterLinesElixir.BoardStateTest do
   alias LetterLinesElixir.BoardState
   alias LetterLinesElixir.BoardWord
 
-  # TODO: Fix the empty first row
+  # Visualization of "good board state"
+
   #   0 1 2 3 4 5
-  # 0
-  # 1           b
-  # 2 c u r b   u
-  # 3 h     u   n
-  # 4 u     r   c
-  # 5 b r u n c h
+  # 0           b
+  # 1 c u r b   u
+  # 2 h     u   n
+  # 3 u     r   c
+  # 4 b r u n c h
   @board_words [
-    BoardWord.new(5, 1, :v, "bunch"),
-    BoardWord.new(0, 2, :v, "chub"),
-    BoardWord.new(3, 2, :v, "burn"),
-    BoardWord.new(0, 2, :h, "curb"),
-    BoardWord.new(0, 5, :h, "brunch")
+    BoardWord.new(5, 0, :v, "bunch"),
+    BoardWord.new(0, 1, :v, "chub"),
+    BoardWord.new(3, 1, :v, "burn"),
+    BoardWord.new(0, 1, :h, "curb"),
+    BoardWord.new(0, 4, :h, "brunch")
   ]
-  @bad_board_words [
+  @colliding_board_words [
     BoardWord.new(5, 0, :v, "bunch"),
     BoardWord.new(5, 0, :v, "chub"),
     BoardWord.new(3, 2, :v, "burn"),
-    BoardWord.new(4, 2, :h, "curb"),
+    BoardWord.new(0, 2, :h, "curb"),
     BoardWord.new(5, 0, :h, "brunch")
   ]
 
   describe "new/1" do
     test "returns proper width and height values" do
-      assert %BoardState{width: 6, height: 6} = BoardState.new(@board_words)
+      assert %BoardState{width: 6, height: 5} = BoardState.new(@board_words)
     end
 
     test "returns expected board words" do
@@ -37,10 +37,61 @@ defmodule LetterLinesElixir.BoardStateTest do
       assert %BoardState{words: ^words} = BoardState.new(@board_words)
     end
 
-    test "will raise on a bad BoardState" do
+    test "will raise when multiple letters are found at the same location" do
       assert_raise RuntimeError, "Multiple letters found at 5, 0: [\"b\", \"c\"]", fn ->
-        BoardState.new(@bad_board_words)
+        BoardState.new(@colliding_board_words)
       end
+    end
+
+    test "will raise if an empty column is found" do
+      assert_raise RuntimeError, "No letters found in first column", fn ->
+        BoardState.new([BoardWord.new(5, 0, :v, "bunch"), BoardWord.new(1, 0, :v, "chub")])
+      end
+    end
+
+    test "will raise if an empty row is found" do
+      assert_raise RuntimeError, "No letters found in first row", fn ->
+        BoardState.new([BoardWord.new(0, 5, :h, "bunch"), BoardWord.new(0, 1, :h, "chub")])
+      end
+    end
+
+    test "will raise if a word touches the beginning of a vertical word" do
+      assert_raise RuntimeError, "Letter found before vertical word: burn", fn ->
+        BoardState.new([
+          BoardWord.new(0, 0, :h, "bunch"),
+          BoardWord.new(0, 1, :v, "burn")
+        ])
+      end
+    end
+
+    test "will raise if a word touches the end of a vertical word" do
+      assert_raise RuntimeError, "Letter found after vertical word: burn", fn ->
+        BoardState.new([
+          BoardWord.new(0, 4, :h, "bunch"),
+          BoardWord.new(0, 0, :v, "burn")
+        ])
+      end
+    end
+
+    test "will raise if a word touches the beginning of a horizontal word" do
+      assert_raise RuntimeError, "Letter found before horizontal word: bunch", fn ->
+        BoardState.new([
+          BoardWord.new(1, 0, :h, "bunch"),
+          BoardWord.new(0, 0, :v, "burn")
+        ])
+      end
+    end
+
+    test "will raise if a word touches the end of a horizontal word" do
+      assert_raise RuntimeError, "Letter found after horizontal word: bunch", fn ->
+        BoardState.new([
+          BoardWord.new(0, 0, :h, "bunch"),
+          BoardWord.new(5, 0, :v, "burn")
+        ])
+      end
+    end
+
+    test "will raise if a parallel word is touching another word" do
     end
   end
 
@@ -48,10 +99,10 @@ defmodule LetterLinesElixir.BoardStateTest do
     test "returns :none when there is no letter at given location" do
       board_state = BoardState.new(@board_words)
       assert :none = BoardState.get_letter_at(board_state, 1, 0)
-      assert :none = BoardState.get_letter_at(board_state, 1, 4)
-      assert :none = BoardState.get_letter_at(board_state, 2, 1)
+      assert :none = BoardState.get_letter_at(board_state, 1, 3)
+      assert :none = BoardState.get_letter_at(board_state, 2, 2)
       assert :none = BoardState.get_letter_at(board_state, 4, 3)
-      assert :none = BoardState.get_letter_at(board_state, 5, 0)
+      assert :none = BoardState.get_letter_at(board_state, 0, 0)
     end
 
     test "returns the letter when found at given location" do
@@ -59,9 +110,9 @@ defmodule LetterLinesElixir.BoardStateTest do
 
     test "raises when multiple letters are found at the same location" do
       board_state = %BoardState{
-        words: @bad_board_words,
+        words: @colliding_board_words,
         width: 6,
-        height: 6
+        height: 5
       }
 
       assert_raise RuntimeError, "Multiple letters found at 5, 0: [\"b\", \"c\"]", fn ->


### PR DESCRIPTION
Check whether the first row or column is empty, and whether a word is
adjacent to the beginning or end of another word. Add tests to cover
these cases